### PR TITLE
fix: missing extension for utils export

### DIFF
--- a/packages/multiplexing/src/promise.js
+++ b/packages/multiplexing/src/promise.js
@@ -1,4 +1,4 @@
-import { isDefined } from './utils';
+import { isDefined } from './utils.js';
 
 export class LazyValue {
   _valuePromise;


### PR DESCRIPTION
Hi,

while [integrating](https://www.npmjs.com/package/@id5io/id5-api.js#indexjs) the ID5 package, I'm facing a problem similar to [the one](https://github.com/id5io/id5-api.js/issues/18) that was raised some time ago.
It's related to an export that is missing the extension in the multiplexing package and is preventing me from building our application.

```
Bundling failed after 0.1s (3 assets with a total size of 557 kiB)
! Module not found: Error: Can't resolve './utils' in 'node_modules/@id5io/multiplexing/src'
Did you mean 'utils.js'?
BREAKING CHANGE: The request './utils' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
```